### PR TITLE
remove extra fn block and fn anti-pattern

### DIFF
--- a/jobs/upsertCasesToONA.js
+++ b/jobs/upsertCasesToONA.js
@@ -23,6 +23,4 @@ fn(state => {
   return { ...state, onaData };
 });
 
-each('onaData[*]', state => {
-  return upsert('cases', 'cases', state.data)(state);
-});
+each('onaData[*]', upsert('cases', 'cases', state.data));

--- a/jobs/upsertCasesToONA.js
+++ b/jobs/upsertCasesToONA.js
@@ -1,4 +1,4 @@
-fn(state => {
+fn(state => {  
   const applyMapping = primeroCase => {
     return {
       cases: primeroCase.case_id_display,
@@ -12,14 +12,14 @@ fn(state => {
       district: primeroCase.location_caregiver,
     };
   };
-  return { ...state, applyMapping };
-});
-
-fn(state => {
+  
+  const { childrenUndergoingReintegration, ageUnder18 } = state.data;
+  
   const onaData = [
-    ...state.data.childrenUndergoingReintegration,
-    ...state.data.ageUnder18,
+    ...childrenUndergoingReintegration,
+    ...ageUnder18,
   ].map(state.applyMapping);
+  
   return { ...state, onaData };
 });
 


### PR DESCRIPTION
My first commit here is debatable, but the second one is to remove that dreaded anti-pattern! Careful not to re-implement `execute` or `each`.