### PR TITLE
Cleaning up final state 

### DIFF
--- a/jobs/upsertCasesToONA.js
+++ b/jobs/upsertCasesToONA.js
@@ -298,7 +298,14 @@ fn((state) => {
 
 upsertMany("services", "unique_id", (state) => state.allServices);
 
-// What is happening here ?
-// fn((state) => {
-//   return { ...state };
-// });
+// Cleaning up final state that will be passed to request-next-batch
+// Notice the client key, it's important to include that key because it's being
+// used by the adaptor for hanlding DB connection
+const { client, metadataForAgeRequest, metadataForTypeofCaseRequest } = state;
+
+  return {
+    client,
+    metadataForAgeRequest,
+    metadataForTypeofCaseRequest,
+  };
+});

--- a/jobs/upsertCasesToONA.js
+++ b/jobs/upsertCasesToONA.js
@@ -301,7 +301,8 @@ upsertMany("services", "unique_id", (state) => state.allServices);
 // Cleaning up final state that will be passed to request-next-batch
 // Notice the client key, it's important to include that key because it's being
 // used by the adaptor for hanlding DB connection
-const { client, metadataForAgeRequest, metadataForTypeofCaseRequest } = state;
+fn(state => { 
+  const { client, metadataForAgeRequest, metadataForTypeofCaseRequest } = state;
 
   return {
     client,


### PR DESCRIPTION
### Summary
This PR addresses #22, which was cause by passing the entire final state to `request-next-batch` job. The fix just returns only the data we need for the next job to proceed 